### PR TITLE
close https://github.com/CommonWealthRobotics/BowlerStudio/issues/339

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -176,8 +176,6 @@ dependencies {
 	compile group: 'commons-lang', name: 'commons-lang', version: '2.6'
 	compile group: 'commons-codec', name: 'commons-codec', version: '1.7'
 		
-	// https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit
-	compile group: 'org.eclipse.jgit', name: 'org.eclipse.jgit', version: '5.6.0.201912101111-r'
 	
 	compile group: 'com.squareup.okhttp', name: 'okhttp-urlconnection', version: '2.0.0'
 	compile group: 'org.mockito', name: 'mockito-all', version: '1.9.5'

--- a/build.gradle
+++ b/build.gradle
@@ -176,6 +176,8 @@ dependencies {
 	compile group: 'commons-lang', name: 'commons-lang', version: '2.6'
 	compile group: 'commons-codec', name: 'commons-codec', version: '1.7'
 		
+	// https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit
+implementation group: 'org.eclipse.jgit', name: 'org.eclipse.jgit', version: '5.13.1.202206130422-r'
 	
 	compile group: 'com.squareup.okhttp', name: 'okhttp-urlconnection', version: '2.0.0'
 	compile group: 'org.mockito', name: 'mockito-all', version: '1.9.5'

--- a/src/main/java/com/neuronrobotics/bowlerstudio/scripting/ScriptingWebWidget.java
+++ b/src/main/java/com/neuronrobotics/bowlerstudio/scripting/ScriptingWebWidget.java
@@ -107,7 +107,6 @@ public class ScriptingWebWidget extends BorderPane implements ChangeListener<Obj
 			new Thread() {
 				public void run() {
 					doFork();
-
 				}
 
 
@@ -142,7 +141,6 @@ public class ScriptingWebWidget extends BorderPane implements ChangeListener<Obj
 				File file = ScriptingEngine.fileFromGit(newGit, currentFile.getName());
 				BowlerStudio.createFileTab(file);
 			} catch (Exception e) {
-				// TODO Auto-generated catch block
 				e.printStackTrace();
 			}
 		}


### PR DESCRIPTION
this PR should address the case where SSH is configured for git access per  https://github.com/CommonWealthRobotics/BowlerStudio/issues/339

to test first set up SSH keys on your local system and add a public key to GitHub

test that you can clone a github URL in SSH mode

next modify your `~/.gitconfig` file and add 

```
[url "git@github.com:"]
  insteadOf = https://github.com/

```

test in the command line that when you clone an `https` url from github is successfully cloned as an ssh URL substituted in.

next erase ~/bowler-workspace/gitcache/ 

open bowlerstudio and verify it opens correctly.