### PR TITLE
Limit Z-move/drag to within reasonable range

### DIFF
--- a/src/main/java/com/neuronrobotics/bowlerstudio/threed/BowlerStudio3dEngine.java
+++ b/src/main/java/com/neuronrobotics/bowlerstudio/threed/BowlerStudio3dEngine.java
@@ -340,7 +340,8 @@ public class BowlerStudio3dEngine implements ICameraChangeListener, IMobileBaseU
 			else
 				t = ((fixedX - ox) * dx + (fixedY - oy) * dy) / denom;
 
-			return localOrigin.getZ() + t * localDir.z;
+			// Limit range to within -1200 and +1200mm
+			return Math.max(-1200, Math.min(localOrigin.getZ() + t * localDir.z, 1200));
 
 		} catch (NonInvertibleTransformException e) {
 			return 0;


### PR DESCRIPTION
Limit Z-move/drag to within reasonable range
Range: -1200 to +1200mm
Note 1: The handle position is limited, the Z-arrow it's 5mm above the object.
Note 2: Typing in very high values is still possible (unwanted).